### PR TITLE
Upgrade to Go 1.15.x and Go Modules migration

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 // Ensure that a bucket that gets a non-existent key returns nil.

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -19,7 +19,7 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 var (

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/boltdb/bolt"
-	"github.com/boltdb/bolt/cmd/bolt"
+	"github.com/sdbeard/bolt"
+	"github.com/sdbeard/bolt/cmd/bolt"
 )
 
 // Ensure the "info" command can print information about a database.

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 // Ensure that a cursor can return a reference to the bucket that created it.

--- a/db_test.go
+++ b/db_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 var statsFlag = flag.Bool("stats", false, "show performance stats")

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/sdbeard/bolt
+
+go 1.15
+
+require golang.org/x/sys v0.0.0-20201223074533-0d417f636930

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930 h1:vRgIt+nup/B/BwIS0g2oC0haq0iqbV3ZA+u6+0TlNCo=
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 func TestSimulate_1op_1p(t *testing.T)     { testSimulate(t, 1, 1) }

--- a/tx_test.go
+++ b/tx_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/sdbeard/bolt"
 )
 
 // Ensure that committing a closed transaction returns an error.


### PR DESCRIPTION
Upgraded the source to use Go modules and modified the reference to the base module were updated from the original source files to matched the forked repository path.